### PR TITLE
Support Promise-based and object-style listen (Fastify compat)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,4 @@ export type {
 } from "./types";
 export type { ResolveOptions } from "./resolver";
 export type { ParseOptions } from "./parser";
-export type { ServerLike, Service, RunOptions, StartupOptions } from "./startup";
+export type { ServerLike, Service, RunOptions, StartupOptions, ListenOptions } from "./startup";


### PR DESCRIPTION
## Summary

- Add `ListenOptions` interface for `{ port, host }` style
- `ServerLike.listen` now accepts `number | ListenOptions`, returns `void | Promise`
- Add `host` to `RunOptions`, pass object when host provided
- Handle Promise rejection from listen

## Test plan

- [x] Existing callback-style tests pass
- [x] New Promise-based listen test
- [x] New error rejection test

Closes #2