### PR TITLE
feat: add diagnostics to ConfigError and onError hook to bootstrap

### DIFF
--- a/.changeset/cuddly-mice-appear.md
+++ b/.changeset/cuddly-mice-appear.md
@@ -1,0 +1,6 @@
+---
+"@confts/bootstrap": patch
+"confts": patch
+---
+
+Better error handling with diagnostics

--- a/packages/confts/src/errors.ts
+++ b/packages/confts/src/errors.ts
@@ -1,10 +1,13 @@
+import type { DiagnosticEvent } from "./types";
+
 export class ConfigError extends Error {
   name = "ConfigError";
 
   constructor(
     message: string,
     public readonly path: string,
-    public readonly sensitive: boolean
+    public readonly sensitive: boolean,
+    public readonly diagnostics?: DiagnosticEvent[]
   ) {
     super(message);
   }

--- a/packages/confts/src/resolve.ts
+++ b/packages/confts/src/resolve.ts
@@ -42,7 +42,8 @@ export function resolve<S extends ConftsSchema<Record<string, unknown>>>(
       throw new ConfigError(
         `Unsupported config file extension: ${ext}. Supported: ${supported || "none"}. Install @confts/yaml-loader for YAML support.`,
         configPath,
-        false
+        false,
+        collector.getEvents()
       );
     }
 
@@ -54,7 +55,8 @@ export function resolve<S extends ConftsSchema<Record<string, unknown>>>(
       throw new ConfigError(
         `Config file not found: ${configPath}`,
         configPath,
-        false
+        false,
+        collector.getEvents()
       );
     }
   } else {

--- a/packages/confts/src/values.ts
+++ b/packages/confts/src/values.ts
@@ -198,7 +198,8 @@ function resolveValue(
     throw new ConfigError(
       `Missing required config at '${pathStr}' (value: ${formatValue(value, sensitive)})`,
       pathStr,
-      sensitive
+      sensitive,
+      collector.getEvents()
     );
   }
 
@@ -208,7 +209,8 @@ function resolveValue(
     throw new ConfigError(
       `Invalid config at '${pathStr}': ${result.error.issues[0]?.message} (value: ${formatValue(value, sensitive)})`,
       pathStr,
-      sensitive
+      sensitive,
+      collector.getEvents()
     );
   }
 

--- a/packages/confts/test/errors.test.ts
+++ b/packages/confts/test/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ConfigError, formatValue } from "../src/errors";
+import type { DiagnosticEvent } from "../src/types";
 
 describe("ConfigError", () => {
   it("stores path and sensitive flag", () => {
@@ -13,6 +14,19 @@ describe("ConfigError", () => {
   it("is instanceof Error", () => {
     const err = new ConfigError("msg", "key", false);
     expect(err).toBeInstanceOf(Error);
+  });
+
+  it("stores diagnostics when provided", () => {
+    const diagnostics: DiagnosticEvent[] = [
+      { type: "sourceDecision", key: "db.host", picked: "env:DB_HOST", tried: ["env:DB_HOST"] },
+    ];
+    const err = new ConfigError("missing value", "db.password", true, diagnostics);
+    expect(err.diagnostics).toEqual(diagnostics);
+  });
+
+  it("has undefined diagnostics when not provided", () => {
+    const err = new ConfigError("msg", "key", false);
+    expect(err.diagnostics).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- ConfigError now includes optional `diagnostics` property with events collected before the error
- bootstrap `onError` callback receives all errors (config validation + factory failures)

Closes #28

## Test plan
- [x] ConfigError stores diagnostics when provided
- [x] resolveValues attaches diagnostics on missing required/validation fail
- [x] resolve attaches diagnostics on unsupported extension/missing file
- [x] bootstrap onError receives ConfigError with diagnostics
- [x] bootstrap onError receives factory errors too